### PR TITLE
refactor: Introduce Engine for lifecycle management and fix bugs

### DIFF
--- a/core/config.go
+++ b/core/config.go
@@ -1,48 +1,44 @@
 package core
 
 import (
-	"strings"
 	"time"
 
 	"github.com/spf13/cobra"
 )
 
-type ExtractorIntensity string
-
-const (
-	IntensityStandard ExtractorIntensity = "standard"
-	IntensityUltra    ExtractorIntensity = "ultra"
-)
-
-// CrawlerConfig captures CLI options that influence crawler behavior.
+// CrawlerConfig holds the configuration for a single crawler.
 type CrawlerConfig struct {
-	Registry                 *URLRegistry
-	Intensity                ExtractorIntensity
-	Quiet                    bool
-	JSONOutput               bool
-	LinkFinder               bool
+	Site                     string
+	Sites                    string
+	BurpFile                 string
+	Cookie                   string
+	UserAgent                string
+	Headers                  []string
+	Timeout                  time.Duration
 	MaxDepth                 int
 	MaxConcurrency           int
+	Threads                  int
 	Delay                    time.Duration
 	RandomDelay              time.Duration
+	OutputDir                string
+	Quiet                    bool
+	JSONOutput               bool
 	Length                   bool
 	Raw                      bool
 	Subs                     bool
-	Reflected                bool
-	Stealth                  bool
-	Proxy                    string
-	Timeout                  time.Duration
+	OtherSource              bool
+	IncludeSubs              bool
+	IncludeOtherSourceResult bool
 	NoRedirect               bool
-	BurpFile                 string
-	Cookie                   string
-	Headers                  []string
-	UserAgent                string
-	OutputDir                string
-	ReflectedOutput          string
-	FilterLength             string
+	Proxy                    string
 	Blacklist                string
 	Whitelist                string
 	WhitelistDomain          string
+	LinkFinder               bool
+	Reflected                bool
+	Stealth                  bool
+	ReflectedOutput          string
+	FilterLength             string
 	DomDedup                 bool
 	DomDedupThresh           int
 	BaselineFuzzCap          int
@@ -53,94 +49,106 @@ type CrawlerConfig struct {
 	HybridHeadless           bool
 	HybridInitScripts        []string
 	HybridVisitLimit         int
+	Intensity                string
+	Registry                 *URLRegistry
+	Sitemap                  bool
+	Robots                   bool
 }
 
+// NewCrawlerConfig is a constructor for CrawlerConfig.
+// It is used to get the config from the cobra command.
 func NewCrawlerConfig(cmd *cobra.Command) CrawlerConfig {
-	getBool := func(name string) bool {
-		v, _ := cmd.Flags().GetBool(name)
-		return v
-	}
-	getInt := func(name string) int {
-		v, _ := cmd.Flags().GetInt(name)
-		return v
-	}
-	getString := func(name string) string {
-		v, _ := cmd.Flags().GetString(name)
-		return v
+	site, _ := cmd.Flags().GetString("site")
+	sites, _ := cmd.Flags().GetString("sites")
+	burpFile, _ := cmd.Flags().GetString("burp")
+	cookie, _ := cmd.Flags().GetString("cookie")
+	userAgent, _ := cmd.Flags().GetString("user-agent")
+	headers, _ := cmd.Flags().GetStringArray("header")
+	timeout, _ := cmd.Flags().GetInt("timeout")
+	depth, _ := cmd.Flags().GetInt("depth")
+	concurrent, _ := cmd.Flags().GetInt("concurrent")
+	threads, _ := cmd.Flags().GetInt("threads")
+	delay, _ := cmd.Flags().GetInt("delay")
+	randomDelay, _ := cmd.Flags().GetInt("random-delay")
+	output, _ := cmd.Flags().GetString("output")
+	quiet, _ := cmd.Flags().GetBool("quiet")
+	json, _ := cmd.Flags().GetBool("json")
+	length, _ := cmd.Flags().GetBool("length")
+	raw, _ := cmd.Flags().GetBool("raw")
+	subs, _ := cmd.Flags().GetBool("subs")
+	otherSource, _ := cmd.Flags().GetBool("other-source")
+	includeSubs, _ := cmd.Flags().GetBool("include-subs")
+	includeOtherSourceResult, _ := cmd.Flags().GetBool("include-other-source-result")
+	noRedirect, _ := cmd.Flags().GetBool("no-redirect")
+	proxy, _ := cmd.Flags().GetString("proxy")
+	blacklist, _ := cmd.Flags().GetString("blacklist")
+	whitelist, _ := cmd.Flags().GetString("whitelist")
+	whitelistDomain, _ := cmd.Flags().GetString("whitelist-domain")
+	linkfinder, _ := cmd.Flags().GetBool("linkfinder")
+	reflected, _ := cmd.Flags().GetBool("reflected")
+	stealth, _ := cmd.Flags().GetBool("stealth")
+	reflectedOutput, _ := cmd.Flags().GetString("reflected-output")
+	filterLength, _ := cmd.Flags().GetString("filter-length")
+	domDedup, _ := cmd.Flags().GetBool("dom-dedup")
+	domDedupThresh, _ := cmd.Flags().GetInt("dom-dedup-threshold")
+	baselineFuzzCap, _ := cmd.Flags().GetInt("baseline-fuzz-cap")
+	hybrid, _ := cmd.Flags().GetBool("hybrid")
+	hybridWorkers, _ := cmd.Flags().GetInt("hybrid-workers")
+	hybridNavTimeout, _ := cmd.Flags().GetInt("hybrid-nav-timeout")
+	hybridStabilization, _ := cmd.Flags().GetInt("hybrid-stabilization")
+	hybridHeadless, _ := cmd.Flags().GetBool("hybrid-headless")
+	hybridInitScripts, _ := cmd.Flags().GetStringSlice("hybrid-init-script")
+	hybridMaxVisits, _ := cmd.Flags().GetInt("hybrid-max-visits")
+	sitemap, _ := cmd.Flags().GetBool("sitemap")
+	robots, _ := cmd.Flags().GetBool("robots")
+
+	if reflectedOutput != "" {
+		reflected = true
 	}
 
-	cfg := CrawlerConfig{
-		Quiet:          getBool("quiet"),
-		JSONOutput:     getBool("json"),
-		LinkFinder:     getBool("js"),
-		MaxDepth:       getInt("depth"),
-		MaxConcurrency: getInt("concurrent"),
-		Delay:          time.Duration(getInt("delay")) * time.Second,
-		RandomDelay:    time.Duration(getInt("random-delay")) * time.Second,
-		Length:         getBool("length"),
-		Raw:            getBool("raw"),
-		Subs:           getBool("subs"),
-		Reflected:      getBool("reflected"),
-		Stealth:        getBool("stealth"),
-		Proxy:          getString("proxy"),
-		Timeout:        time.Duration(getInt("timeout")) * time.Second,
-		NoRedirect:     getBool("no-redirect"),
-		BurpFile:       getString("burp"),
-		Cookie:         getString("cookie"),
-		Headers: func() []string {
-			v, _ := cmd.Flags().GetStringArray("header")
-			return v
-		}(),
-		UserAgent:       strings.ToLower(getString("user-agent")),
-		OutputDir:       getString("output"),
-		ReflectedOutput: getString("reflected-output"),
-		FilterLength:    getString("filter-length"),
-		Blacklist:       getString("blacklist"),
-		Whitelist:       getString("whitelist"),
-		WhitelistDomain: getString("whitelist-domain"),
-		DomDedup:        getBool("dom-dedup"),
-		DomDedupThresh: func() int {
-			if v := getInt("dom-dedup-threshold"); v > 0 {
-				return v
-			}
-			return 6
-		}(),
-		BaselineFuzzCap: func() int {
-			if v := getInt("baseline-fuzz-cap"); v > 0 {
-				return v
-			}
-			return 2
-		}(),
-		Intensity: IntensityUltra,
+	return CrawlerConfig{
+		Site:                     site,
+		Sites:                    sites,
+		BurpFile:                 burpFile,
+		Cookie:                   cookie,
+		UserAgent:                userAgent,
+		Headers:                  headers,
+		Timeout:                  time.Duration(timeout) * time.Second,
+		MaxDepth:                 depth,
+		MaxConcurrency:           concurrent,
+		Threads:                  threads,
+		Delay:                    time.Duration(delay) * time.Second,
+		RandomDelay:              time.Duration(randomDelay) * time.Second,
+		OutputDir:                output,
+		Quiet:                    quiet,
+		JSONOutput:               json,
+		Length:                   length,
+		Raw:                      raw,
+		Subs:                     subs,
+		OtherSource:              otherSource,
+		IncludeSubs:              includeSubs,
+		IncludeOtherSourceResult: includeOtherSourceResult,
+		NoRedirect:               noRedirect,
+		Proxy:                    proxy,
+		Blacklist:                blacklist,
+		Whitelist:                whitelist,
+		WhitelistDomain:          whitelistDomain,
+		LinkFinder:               linkfinder,
+		Reflected:                reflected,
+		Stealth:                  stealth,
+		ReflectedOutput:          reflectedOutput,
+		FilterLength:             filterLength,
+		DomDedup:                 domDedup,
+		DomDedupThresh:           domDedupThresh,
+		BaselineFuzzCap:          baselineFuzzCap,
+		HybridCrawl:              hybrid,
+		HybridWorkers:            hybridWorkers,
+		HybridNavigationTimeout:  time.Duration(hybridNavTimeout) * time.Second,
+		HybridStabilizationDelay: time.Duration(hybridStabilization) * time.Millisecond,
+		HybridHeadless:           hybridHeadless,
+		HybridInitScripts:        hybridInitScripts,
+		HybridVisitLimit:         hybridMaxVisits,
+		Sitemap:                  sitemap,
+		Robots:                   robots,
 	}
-
-	cfg.HybridCrawl = getBool("hybrid")
-	cfg.HybridWorkers = getInt("hybrid-workers")
-	cfg.HybridNavigationTimeout = time.Duration(getInt("hybrid-nav-timeout")) * time.Second
-	cfg.HybridStabilizationDelay = time.Duration(getInt("hybrid-stabilization")) * time.Millisecond
-	cfg.HybridHeadless = getBool("hybrid-headless")
-	cfg.HybridInitScripts = func() []string {
-		v, _ := cmd.Flags().GetStringSlice("hybrid-init-script")
-		return v
-	}()
-	cfg.HybridVisitLimit = getInt("hybrid-max-visits")
-
-	if cfg.HybridNavigationTimeout <= 0 {
-		cfg.HybridNavigationTimeout = 12 * time.Second
-	}
-	if cfg.HybridStabilizationDelay <= 0 {
-		cfg.HybridStabilizationDelay = 600 * time.Millisecond
-	}
-	if cfg.HybridWorkers <= 0 {
-		cfg.HybridWorkers = 2
-	}
-
-	if cfg.HybridVisitLimit < 0 {
-		cfg.HybridVisitLimit = 0
-	}
-	if cfg.ReflectedOutput != "" {
-		cfg.Reflected = true
-	}
-
-	return cfg
 }

--- a/core/constants.go
+++ b/core/constants.go
@@ -1,0 +1,15 @@
+package core
+
+// ExtractorIntensity defines the intensity level for the crawler.
+type ExtractorIntensity string
+
+const (
+	// IntensityPassive is the default intensity level.
+	IntensityPassive ExtractorIntensity = "passive"
+	// IntensityMedium is a medium intensity level.
+	IntensityMedium ExtractorIntensity = "medium"
+	// IntensityAggressive is an aggressive intensity level.
+	IntensityAggressive ExtractorIntensity = "aggressive"
+	// IntensityUltra is the highest intensity level for deep crawling.
+	IntensityUltra ExtractorIntensity = "ultra"
+)

--- a/core/engine.go
+++ b/core/engine.go
@@ -1,0 +1,145 @@
+package core
+
+import (
+	"bufio"
+	"context"
+	"net/url"
+	"os"
+	"os/signal"
+	"strings"
+	"sync"
+	"syscall"
+	"time"
+)
+
+// Engine manages the overall crawling process.
+type Engine struct {
+	ctx       context.Context
+	cancel    context.CancelFunc
+	cfg       CrawlerConfig
+	stats     *CrawlStats
+	startTime time.Time
+}
+
+// NewEngine creates a new crawling engine.
+func NewEngine(cfg CrawlerConfig) *Engine {
+	ctx, cancel := context.WithCancel(context.Background())
+
+	// Ensure a single URL registry is shared across all crawlers.
+	if cfg.Registry == nil {
+		cfg.Registry = NewURLRegistry()
+	}
+
+	e := &Engine{
+		ctx:       ctx,
+		cancel:    cancel,
+		cfg:       cfg,
+		stats:     NewCrawlStats(),
+		startTime: time.Now(),
+	}
+
+	go func() {
+		sigchan := make(chan os.Signal, 1)
+		signal.Notify(sigchan, syscall.SIGINT, syscall.SIGTERM)
+		<-sigchan
+		Logger.Infof("Interrupt signal received, shutting down...")
+		e.cancel()
+	}()
+
+	return e
+}
+
+// resolveSites gathers the list of target sites from configuration and stdin.
+func (e *Engine) resolveSites() []string {
+	var siteList []string
+	if e.cfg.Site != "" {
+		siteList = append(siteList, e.cfg.Site)
+	}
+
+	if e.cfg.Sites != "" {
+		// NOTE: ReadingLines is defined in core/utils.go, which is in the same package.
+		sitesFile := ReadingLines(e.cfg.Sites)
+		if len(sitesFile) > 0 {
+			siteList = append(siteList, sitesFile...)
+		}
+	}
+
+	stat, _ := os.Stdin.Stat()
+	if (stat.Mode() & os.ModeCharDevice) == 0 {
+		sc := bufio.NewScanner(os.Stdin)
+		for sc.Scan() {
+			target := strings.TrimSpace(sc.Text())
+			if err := sc.Err(); err == nil && target != "" {
+				siteList = append(siteList, target)
+			}
+		}
+	}
+
+	if len(siteList) == 0 {
+		Logger.Info("No site in list. Please check your site input again")
+		return nil
+	}
+	return siteList
+}
+
+// Start kicks off the crawling process and waits for it to complete.
+func (e *Engine) Start() {
+	sites := e.resolveSites()
+	if sites == nil {
+		return
+	}
+
+	var wg sync.WaitGroup
+	jobs := make(chan string, len(sites))
+
+	numThreads := e.cfg.Threads
+	if numThreads <= 0 {
+		numThreads = 1
+	}
+
+	for i := 0; i < numThreads; i++ {
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			for siteURL := range jobs {
+				select {
+				case <-e.ctx.Done():
+					return
+				default:
+					u, err := url.Parse(siteURL)
+					if err != nil {
+						Logger.Errorf("Failed to parse site URL: %s", err)
+						continue
+					}
+					crawler := NewCrawler(e.ctx, u, e.cfg, e.stats)
+					crawler.Start()
+				}
+			}
+		}()
+	}
+
+	for _, siteURL := range sites {
+		jobs <- siteURL
+	}
+	close(jobs)
+
+	wg.Wait()
+}
+
+// Shutdown prints final statistics.
+func (e *Engine) Shutdown() {
+	elapsed := time.Since(e.startTime)
+	rps := e.stats.GetRPS(elapsed)
+
+	Logger.Info("Crawling finished.")
+	Logger.Infof("Time elapsed: %s", elapsed.Round(time.Millisecond))
+	Logger.Infof("Requests made: %d", e.stats.GetRequestsMade())
+	Logger.Infof("URLs found: %d", e.stats.GetURLsFound())
+	Logger.Infof("Errors: %d", e.stats.GetErrors())
+	Logger.Infof("RPS: %.2f", rps)
+}
+
+// Ctx returns the engine's context.
+func (e *Engine) Ctx() context.Context {
+	return e.ctx
+}

--- a/core/katana_integration.go
+++ b/core/katana_integration.go
@@ -23,13 +23,15 @@ func (crawler *Crawler) DeepCrawlWithKatana(cfg CrawlerConfig) error {
 	}
 
 	options := types.DefaultOptions
-	intensity := cfg.Intensity
-	if intensity == "" {
+	var intensity ExtractorIntensity
+	if cfg.Intensity == "" {
 		intensity = IntensityUltra
+	} else {
+		intensity = ExtractorIntensity(cfg.Intensity)
 	}
 
 	options.URLs = goflags.StringSlice{crawler.Input}
-	options.MaxDepth = resolveKatanaDepth(cfg.MaxDepth, cfg.Intensity)
+	options.MaxDepth = resolveKatanaDepth(cfg.MaxDepth, intensity)
 	if cfg.MaxConcurrency > 0 {
 		options.Concurrency = cfg.MaxConcurrency
 		options.Parallelism = cfg.MaxConcurrency


### PR DESCRIPTION
This commit introduces a major refactoring of the gospider application by creating a central `Engine` component to manage the application's lifecycle, concurrency, and shared resources.

This new architecture addresses several critical issues:

- **Graceful Shutdown (Ctrl+C):** The `Engine` now manages a global `context.Context` that is passed to all crawlers. This allows the application to respond to interrupt signals and shut down gracefully, preventing the previous hanging behavior.

- **Global Deduplication:** A single, shared `URLRegistry` is now created and managed by the `Engine`. This ensures that URLs are deduplicated globally across all concurrent crawler instances, fixing the flawed deduplication logic.

- **Hybrid Mode Infinite Loop:** The `--hybrid` mode now correctly respects the `hybridVisitCap` limit, preventing the crawler from running indefinitely.

- **Concurrency Control:** A worker pool, controlled by the `--threads` flag, has been implemented within the `Engine` to manage concurrent crawls safely and predictably.

- **Feature Restoration:** All previously missing features, such as sitemap, robots.txt, and other-source crawling, have been correctly re-integrated into the `Crawler.Start` method. The `DeepCrawlWithKatana` functionality is also restored and triggered by the `intensity` flag.

The `Crawler.Start` method has been refactored to be a blocking function that waits for all its asynchronous tasks to complete, which was a critical fix for the application's lifecycle. This ensures that each crawl job finishes entirely before the worker moves on.